### PR TITLE
Reorder auth offers, NTLM first, Basic at the end

### DIFF
--- a/src/NodeSSPI.cpp
+++ b/src/NodeSSPI.cpp
@@ -109,6 +109,11 @@ void note_sspi_auth_failure(const Handle<Object> opts, const Handle<Object> req,
 	}
 	auto authHArr = Nan::New<v8::Array>(nWays);
 	int curIdx = 0;
+	if (offerSSPI) {
+		for (int i = 0; i < nSSPIPkgs; i++) {
+			authHArr->Set(curIdx++, opts->Get(Nan::New<String>("sspiPackagesUsed").ToLocalChecked())->ToObject()->Get(i));
+		}
+	}
 	if (offerBasic) {
 		std::string basicStr("Basic");
 		if (opts->Has(Nan::New<String>("domain").ToLocalChecked())) {
@@ -118,11 +123,6 @@ void note_sspi_auth_failure(const Handle<Object> opts, const Handle<Object> req,
 			basicStr += "\"";
 		}
 		authHArr->Set(curIdx++, Nan::New<String>(basicStr.c_str()).ToLocalChecked());
-	}
-	if (offerSSPI) {
-		for (int i = 0; i < nSSPIPkgs; i++) {
-			authHArr->Set(curIdx++, opts->Get(Nan::New<String>("sspiPackagesUsed").ToLocalChecked())->ToObject()->Get(i));
-		}
 	}
 	Handle<Value> argv[] = { Nan::New<String>("WWW-Authenticate").ToLocalChecked(), authHArr };
 	res->Get(Nan::New<String>("setHeader").ToLocalChecked())->ToObject()->CallAsFunction(Isolate::GetCurrent()->GetCurrentContext(), res, 2, argv);


### PR DESCRIPTION
Thanks for this Node module. This really helps us with our Express servers in a Windows domain environment.

Here is a small code change to reorder the Authentication offers sent back to the client.

At the moment the client gets 1. Basic and 2. NTLM if `offerBasic` is enable
This leads to a problem we have using the node-sspi module in combination with an Express IPP server. A Windows IPP Printer port then first tries Basic auth and pops up a user+password dialog.

![basic-first-then-ntlm](https://user-images.githubusercontent.com/207759/50060141-28075b80-0190-11e9-99d2-6c0bb4fc6092.jpg)

With the order 1. NTLM and 2. Basic it also works for printer ports without the popup.

![ntlm-first-then-basic](https://user-images.githubusercontent.com/207759/50060146-32295a00-0190-11e9-8bb2-365f031b3d48.jpg)

I have tested the fork with our Express server and now I can connect IPP printers without a user+password dialog.

It would be very helpful to have this order in the code base.

