### PR TITLE
Update binding.gyp to support Node 15+

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,7 @@
       "msvs_settings": {
         "VCCLCompilerTool": { "ExceptionHandling": 1 }
       },
-      "sources": ["src/*.h", "src/*.cpp"],
+      "sources": ["src/NodeSSPI.h", "src/NodeSSPI.cpp"],
       "defines": ["_UNICODE", "UNICODE"],
       "configurations": {
         "Release": {


### PR DESCRIPTION
I was able to successfully run the 'build.js' scrip to compile the node-sspi module binaries after removing the wildcard references in the binding.gyp -> sources property.  

node-gyp@8.1.0
node@16.5.0 | win32 | x64
Python version 3.9.5 found at "C:\Python\Python39\python.exe"
VS2019 (16.10.31424.327) (Community edition)
