### PR TITLE
Fixes two issues I had when compiling for Node v22

### DIFF
--- a/build.js
+++ b/build.js
@@ -62,6 +62,7 @@ if (!force) {
 function build() {
     cp.spawn(
             process.platform === 'win32' ? 'node-gyp.cmd' : 'node-gyp', ['rebuild'].concat(args), {
+        shell: true,
         stdio: 'inherit'
     })
             .on('exit', function (err) {

--- a/src/NodeSSPI.cpp
+++ b/src/NodeSSPI.cpp
@@ -23,7 +23,7 @@ void init_module()
 	INIT_SECURITY_INTERFACE pInit;
 	SECURITY_STATUS ss = SEC_E_INTERNAL_ERROR;
 
-	sspiModuleInfo.defaultPackage = DEFAULT_SSPI_PACKAGE;
+	sspiModuleInfo.defaultPackage = LPSTR(DEFAULT_SSPI_PACKAGE);
 	try {
 		sspiModuleInfo.securityDLL = LoadLibrary(lpDllName);
 		pInit = (INIT_SECURITY_INTERFACE)GetProcAddress(sspiModuleInfo.securityDLL, CW2A(SECURITY_ENTRYPOINT));


### PR DESCRIPTION
I'm sure build.js has to be updated. 
I haven't touched C++ in almost 15 years, but change in CPP file fixed casting error for me. 